### PR TITLE
Add JsonRpcMessage deserialization benchmarks

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -79,5 +79,6 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="JsonSchema.Net" Version="7.3.4" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
   </ItemGroup>
 </Project>

--- a/ModelContextProtocol.slnx
+++ b/ModelContextProtocol.slnx
@@ -40,4 +40,7 @@
     <Project Path="tests/ModelContextProtocol.TestServer/ModelContextProtocol.TestServer.csproj" />
     <Project Path="tests/ModelContextProtocol.TestSseServer/ModelContextProtocol.TestSseServer.csproj" />
   </Folder>
+  <Folder Name="/benchmarks/">
+    <Project Path="benchmarks/ModelContextProtocol.Benchmarks/ModelContextProtocol.Benchmarks.csproj" />
+  </Folder>
 </Solution>

--- a/benchmarks/ModelContextProtocol.Benchmarks/JsonRpcMessageDeserializationBenchmarks.cs
+++ b/benchmarks/ModelContextProtocol.Benchmarks/JsonRpcMessageDeserializationBenchmarks.cs
@@ -1,0 +1,69 @@
+using BenchmarkDotNet.Attributes;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+public class JsonRpcMessageDeserializationBenchmarks
+{
+    private byte[] _requestJson = null!;
+    private byte[] _notificationJson = null!;
+    private byte[] _responseJson = null!;
+    private byte[] _errorJson = null!;
+    private JsonSerializerOptions _options = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _options = McpJsonUtilities.DefaultOptions;
+
+        _requestJson = JsonSerializer.SerializeToUtf8Bytes(
+            new JsonRpcRequest
+            {
+                Id = new RequestId("1"),
+                Method = "test",
+                Params = JsonValue.Create(1)
+            },
+            _options);
+
+        _notificationJson = JsonSerializer.SerializeToUtf8Bytes(
+            new JsonRpcNotification
+            {
+                Method = "notify",
+                Params = JsonValue.Create(2)
+            },
+            _options);
+
+        _responseJson = JsonSerializer.SerializeToUtf8Bytes(
+            new JsonRpcResponse
+            {
+                Id = new RequestId("1"),
+                Result = JsonValue.Create(3)
+            },
+            _options);
+
+        _errorJson = JsonSerializer.SerializeToUtf8Bytes(
+            new JsonRpcError
+            {
+                Id = new RequestId("1"),
+                Error = new JsonRpcErrorDetail { Code = 42, Message = "oops" }
+            },
+            _options);
+    }
+
+    [Benchmark]
+    public JsonRpcMessage DeserializeRequest() =>
+        JsonSerializer.Deserialize<JsonRpcMessage>(_requestJson, _options)!;
+
+    [Benchmark]
+    public JsonRpcMessage DeserializeNotification() =>
+        JsonSerializer.Deserialize<JsonRpcMessage>(_notificationJson, _options)!;
+
+    [Benchmark]
+    public JsonRpcMessage DeserializeResponse() =>
+        JsonSerializer.Deserialize<JsonRpcMessage>(_responseJson, _options)!;
+
+    [Benchmark]
+    public JsonRpcMessage DeserializeError() =>
+        JsonSerializer.Deserialize<JsonRpcMessage>(_errorJson, _options)!;
+}

--- a/benchmarks/ModelContextProtocol.Benchmarks/ModelContextProtocol.Benchmarks.csproj
+++ b/benchmarks/ModelContextProtocol.Benchmarks/ModelContextProtocol.Benchmarks.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ModelContextProtocol.Core\ModelContextProtocol.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/ModelContextProtocol.Benchmarks/Program.cs
+++ b/benchmarks/ModelContextProtocol.Benchmarks/Program.cs
@@ -1,0 +1,3 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);


### PR DESCRIPTION
## Summary
- add BenchmarkDotNet version to centralized package versions
- add ModelContextProtocol.Benchmarks project
- benchmark JsonRpcMessage deserialization for each message type
- include benchmark project in solution

## Testing
- `make test` *(fails: Test host could not start due to missing runtimes)*

------
https://chatgpt.com/codex/tasks/task_e_687e2c7e5610833199f0968e1fbbecaf